### PR TITLE
chore: Bump versions of container and some actions

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -15,10 +15,10 @@ on: pull_request
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2

--- a/.github/workflows/git_fixup.yml
+++ b/.github/workflows/git_fixup.yml
@@ -4,9 +4,9 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,10 +7,10 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: git fetch origin ${GITHUB_BASE_REF}
     - name: Check for FIXMEs
-      uses: luator/github_action_check_new_todos@v1
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: FIXME
           base_ref: origin/${{ github.base_ref }}
@@ -19,10 +19,10 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: git fetch origin ${GITHUB_BASE_REF}
     - name: Check for TODOs
-      uses: luator/github_action_check_new_todos@v1
+      uses: luator/github_action_check_new_todos@v2
       with:
           label: TODO
           base_ref: origin/${{ github.base_ref }}

--- a/.github/workflows/style_checker.yml
+++ b/.github/workflows/style_checker.yml
@@ -7,16 +7,16 @@ jobs:
     name: Python Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: psf/black@stable
 
   clang-format:
     name: C++ Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/scripts/run-clang-format
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/resources/_clang-format
       - run: python ./run-clang-format -r .


### PR DESCRIPTION
- Use ubuntu-latest instead of ubuntu-18.04 (18.04 is out of order since quite some time).
- Bump several actions to latest versions.
